### PR TITLE
relinked R2 and R4 in case_back

### DIFF
--- a/blender/case_back.blend
+++ b/blender/case_back.blend
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6922a36f08d526dda55d41cbf1b6e8b8b9eab5ae78bad0282c389a6fa69b910e
-size 217179
+oid sha256:fdeb8d0414b1b883837aa4ee1df1a76d841ddd520770ad4d1ad84158e7339cd6
+size 211203

--- a/blender/case_front.blend
+++ b/blender/case_front.blend
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:7b7543cbf81dca2da4d60282c997a3b67519f91355de691ef15cc2a468eaef72
-size 199406
+oid sha256:a6e84628dd3525b26dcc46f8f1ed8171fa7ba91917d208bf3242f7648a65a4f2
+size 193277


### PR DESCRIPTION
Hi, 

with a new checkout, when I open the file case_back, the links to R2 and R4 are broken and in case_front the link to R1 is broken.

Tested with blender 4.0.2 and 3.6.4

I relinked them using 4.0.2.

